### PR TITLE
Create and Update functionality for gardens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+# Use Bootstrap forms gem for form formatting
+gem "bootstrap_form", "~> 4.0"
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
+    bootstrap_form (4.5.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -125,7 +128,7 @@ GEM
       activerecord (= 5.2.6)
       activestorage (= 5.2.6)
       activesupport (= 5.2.6)
-      bundler (>= 2.2.17)
+      bundler (>= 1.3.0)
       railties (= 5.2.6)
       sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
@@ -216,6 +219,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap_form (~> 4.0)
   byebug
   capybara
   coffee-rails (~> 4.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,4 @@
 //= require rails-ujs
 //= require activestorage
 //= require_tree .
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
 aside {
   float: right;
 }

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -15,6 +15,21 @@ class GardensController < ApplicationController
      redirect_to '/gardens'
   end
 
+  def edit
+    @garden = Garden.find(params[:id])
+  end
+
+  def update
+    garden = Garden.find(params[:id])
+    garden.update({
+      name: params[:name],
+      water_on: params[:water_on],
+      water_access_pts: params[:water_access_pts]
+      })
+    garden.save
+    redirect_to "/gardens/#{params[:id]}"
+  end
+
   private
     def garden_params
       params.permit(:name, :water_on, :water_access_pts)

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -6,4 +6,7 @@ class GardensController < ApplicationController
   def show
     @garden = Garden.find(params[:id])
   end
+
+  def new
+  end
 end

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -9,4 +9,14 @@ class GardensController < ApplicationController
 
   def new
   end
+
+  def create
+     Garden.create(garden_params)
+     redirect_to '/gardens'
+  end
+
+  private
+    def garden_params
+      params.permit(:name, :water_on, :water_access_pts)
+    end
 end

--- a/app/views/gardens/edit.html.erb
+++ b/app/views/gardens/edit.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @garden.name %></h1>
+
+<%= form_with url: "/gardens/#{@garden.id}", method: :patch, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name, value: @garden.name %><br/>
+  <%= form.label :water_on, 'Water on?' %>
+  <%= form.radio_button :water_on, true, checked: @garden.water_on %>
+  <%= form.label :water_on_true, "Yes" %>
+  <%= form.radio_button :water_on, false, checked: !@garden.water_on%>
+  <%= form.label :water_on_false, "No" %><br/>
+  <%= form.label :water_access_pts, "Water access points" %>
+  <%= form.number_field :water_access_pts, in: 1..100, step: 1, value: @garden.water_access_pts %>
+  <%= form.submit 'Update' %>
+<% end %>

--- a/app/views/gardens/edit.html.erb
+++ b/app/views/gardens/edit.html.erb
@@ -1,14 +1,11 @@
 <h1><%= @garden.name %></h1>
 
-<%= form_with url: "/gardens/#{@garden.id}", method: :patch, local: true do |form| %>
-  <%= form.label :name %>
+<%= bootstrap_form_with url: "/gardens/#{@garden.id}", method: :patch, local: true do |form| %>
   <%= form.text_field :name, value: @garden.name %><br/>
-  <%= form.label :water_on, 'Water on?' %>
-  <%= form.radio_button :water_on, true, checked: @garden.water_on %>
-  <%= form.label :water_on_true, "Yes" %>
-  <%= form.radio_button :water_on, false, checked: !@garden.water_on%>
-  <%= form.label :water_on_false, "No" %><br/>
-  <%= form.label :water_access_pts, "Water access points" %>
-  <%= form.number_field :water_access_pts, in: 1..100, step: 1, value: @garden.water_access_pts %>
+  <%= form.form_group :water_on, label: { text: "Water on for the season?" } do %><br/>
+    <%= form.radio_button :water_on, true, checked: @garden.water_on, label: "Yes", inline:true %>
+    <%= form.radio_button :water_on, false, checked: !@garden.water_on, label: "No", inline:true %>
+  <% end %><br/>
+  <%= form.number_field :water_access_pts, in: 1..100, step: 1, value: @garden.water_access_pts, label: "Water access points available" %><br/>
   <%= form.submit 'Update' %>
 <% end %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -4,7 +4,8 @@
   <div id="garden-<%= garden.id %>">
     <aside><%= garden.created_at %></aside>
     <h3><a href="/gardens/<%= garden.id %>"><%= garden.name %></a></h3>
+    <%= button_to 'Edit', "/gardens/#{garden.id}/edit", method: :get %>
   </div>
 <% end %>
 
-<%= link_to 'Create new garden',  "/gardens/new" %>
+<%= button_to 'New garden',  "/gardens/new", method: :get %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -7,4 +7,4 @@
   </div>
 <% end %>
 
-<%= link_to 'Create new garden',  '/artists/new' %>
+<%= link_to 'Create new garden',  "/gardens/new" %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -6,3 +6,5 @@
     <h3><a href="/gardens/<%= garden.id %>"><%= garden.name %></a></h3>
   </div>
 <% end %>
+
+<%= link_to 'Create new garden',  '/artists/new' %>

--- a/app/views/gardens/new.html.erb
+++ b/app/views/gardens/new.html.erb
@@ -1,9 +1,9 @@
 <%= form_with url: '/gardens', method: :post, local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
-  <%= form.label 'Water on?' %>
+  <%= form.label :water_on, 'Water on?' %>
   <%= form.text_field :water_on %>
-  <%= form.label "Water access points" %>
+  <%= form.label :water_access_pts, "Water access points" %>
   <%= form.text_field :water_access_pts %>
   <%= form.submit 'Create' %>
 <% end %>

--- a/app/views/gardens/new.html.erb
+++ b/app/views/gardens/new.html.erb
@@ -2,8 +2,11 @@
   <%= form.label :name %>
   <%= form.text_field :name %>
   <%= form.label :water_on, 'Water on?' %>
-  <%= form.text_field :water_on %>
+  <%= form.radio_button :water_on, true %>
+  <%= form.label :water_on_true, "Yes" %>
+  <%= form.radio_button :water_on, false %>
+  <%= form.label :water_on_false, "No" %>
   <%= form.label :water_access_pts, "Water access points" %>
-  <%= form.text_field :water_access_pts %>
+  <%= form.number_field :water_access_pts, in: 1..100, step: 1 %>
   <%= form.submit 'Create' %>
 <% end %>

--- a/app/views/gardens/new.html.erb
+++ b/app/views/gardens/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: '/gardens', method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label 'Water on?' %>
+  <%= form.text_field :water_on %>
+  <%= form.label "Water access points" %>
+  <%= form.text_field :water_access_pts %>
+  <%= form.submit 'Create' %>
+<% end %>

--- a/app/views/gardens/new.html.erb
+++ b/app/views/gardens/new.html.erb
@@ -1,12 +1,11 @@
-<%= form_with url: '/gardens', method: :post, local: true do |form| %>
-  <%= form.label :name %>
-  <%= form.text_field :name %>
-  <%= form.label :water_on, 'Water on?' %>
-  <%= form.radio_button :water_on, true %>
-  <%= form.label :water_on_true, "Yes" %>
-  <%= form.radio_button :water_on, false %>
-  <%= form.label :water_on_false, "No" %>
-  <%= form.label :water_access_pts, "Water access points" %>
-  <%= form.number_field :water_access_pts, in: 1..100, step: 1 %>
+<h1>New Garden</h1>
+
+<%= bootstrap_form_with url: '/gardens', method: :post, local: true do |form| %>
+  <%= form.text_field :name %><br/>
+  <%= form.form_group :water_on, label: { text: "Water on for the season?" } do %><br/>
+    <%= form.radio_button :water_on, true, label: "Yes", inline:true %>
+    <%= form.radio_button :water_on, false, label: "No", inline:true %>
+  <% end %><br/>
+  <%= form.number_field :water_access_pts, in: 1..100, step: 1, label: "Water access points available" %><br/>
   <%= form.submit 'Create' %>
 <% end %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -9,4 +9,6 @@
   <li>Last update:  <%= @garden.updated_at %></li>
 </ul>
 
-<button><a href="/gardens/<%= @garden.id %>/plots">See all plots</a></button>
+<%= button_to 'Edit', "/gardens/#{@garden.id}/edit", method: :get %>
+
+<%= button_to 'See all plots', "/gardens/#{@garden.id}/plots", method: :get %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,13 +12,30 @@
   </head>
 
   <body>
-    <nav>
-      <ul>
-        <li><a href='/'>Home</a></li>
-        <li><a href="/gardens">Community Gardens</a></li>
-        <li><a href="/plots">Garden Plots</a></li>
-        <li><a href="/flower_shops">Flower Shops</a></li>
-      </ul>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">FlowerPower</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href='/'>Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/gardens">Community Gardens</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/plots">Garden Plots</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/flower_shops">Flower Shops</a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </nav>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,9 @@
     <title>RelationalRails</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
   </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
   get '/', to: 'welcome#index'
 
   get '/gardens', to: 'gardens#index'
-  get '/gardens/:id', to: 'gardens#show'
   get 'gardens/new', to: 'gardens#new'
+  get '/gardens/:id', to: 'gardens#show'
 
   get '/gardens/:id/plots', to: 'garden_plots#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   get '/gardens', to: 'gardens#index'
   get '/gardens/:id', to: 'gardens#show'
+  get 'gardens/new', to: 'gardens#new'
 
   get '/gardens/:id/plots', to: 'garden_plots#index'
 
@@ -13,5 +14,5 @@ Rails.application.routes.draw do
   get '/flower_shops',to: 'flower_shops#index'
   get '/flower_shops/:id', to: 'flower_shops#show'
 
-  get '/flowers', to: 'flowers#index' 
+  get '/flowers', to: 'flowers#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,11 @@ Rails.application.routes.draw do
   get '/', to: 'welcome#index'
 
   get '/gardens', to: 'gardens#index'
-  get 'gardens/new', to: 'gardens#new'
+  get '/gardens/new', to: 'gardens#new'
   get '/gardens/:id', to: 'gardens#show'
-  post 'gardens', to: 'gardens#create'
+  post '/gardens', to: 'gardens#create'
+  get '/gardens/:id/edit', to: 'gardens#edit'
+  patch '/gardens/:id', to: 'gardens#update'
 
   get '/gardens/:id/plots', to: 'garden_plots#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/gardens', to: 'gardens#index'
   get 'gardens/new', to: 'gardens#new'
   get '/gardens/:id', to: 'gardens#show'
+  post 'gardens', to: 'gardens#create'
 
   get '/gardens/:id/plots', to: 'garden_plots#index'
 

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -1,0 +1,52 @@
+# As a visitor
+# When I visit a parent show page
+# Then I see a link to update the parent "Update Parent"
+# When I click the link "Update Parent"
+# Then I am taken to '/parents/:id/edit' where I see a form to edit the parent's attributes:
+# When I fill out the form with updated information
+# And I click the button to submit the form
+# Then a PATCH request is sent to '/parents/:id',
+# the parent's info is updated,
+# and I am redirected to the Parent's Show page where I see the parent's updated info
+
+require 'rails_helper'
+
+RSpec.describe 'update garden' do
+  before :each do
+    @north_boulder = Garden.create!( name:"North Boulder Community Garden",
+                                    water_on: false,
+                                    water_access_pts: 2,
+                                    created_at: Time.parse('2021-02-01')
+                                  )
+  end
+
+  it 'can update just the name of the garden' do
+    visit "/gardens/#{@north_boulder.id}"
+
+    click_button 'Edit'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}/edit")
+
+    fill_in 'Name', with: 'Arborwood Community Garden'
+    click_on 'Update'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}")
+    expect(page).to have_content('Arborwood Community Garden')
+  end
+
+  it 'can update just one attribute of the garden' do
+    visit "/gardens/#{@north_boulder.id}"
+
+    click_button 'Edit'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}/edit")
+
+    choose :water_on, option: true
+    click_on 'Update'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}")
+    expect(page).to have_content('North Boulder Community Garden')
+    expect(page).to have_content('Water on? Yes')
+    expect(page).to have_content('Water access points: 2')
+  end
+end

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'update garden' do
     expect(page).to have_content('Arborwood Community Garden')
   end
 
-  it 'can update just one attribute of the garden' do
+  it 'can update whether the water is on' do
     visit "/gardens/#{@north_boulder.id}"
 
     click_button 'Edit'
@@ -46,7 +46,23 @@ RSpec.describe 'update garden' do
 
     expect(current_path).to eq("/gardens/#{@north_boulder.id}")
     expect(page).to have_content('North Boulder Community Garden')
-    expect(page).to have_content('Water on? Yes')
-    expect(page).to have_content('Water access points: 2')
+    expect(page).to have_content('Water on for the season? Yes')
+    expect(page).to have_content('Water access points available: 2')
+  end
+
+  it 'can update whether the water is on' do
+    visit "/gardens/#{@north_boulder.id}"
+
+    click_button 'Edit'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}/edit")
+
+    fill_in 'Water access points', with: 4
+    click_on 'Update'
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}")
+    expect(page).to have_content('North Boulder Community Garden')
+    expect(page).to have_content('Water on for the season? No')
+    expect(page).to have_content('Water access points available: 4')
   end
 end

--- a/spec/features/gardens/index_spec.rb
+++ b/spec/features/gardens/index_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'gardens index' do
   it 'has a link to create a new garden' do
     visit '/gardens'
 
-    click_button 'New garden'
+    click_button 'Create new garden'
 
     expect(current_path).to eq('/gardens/new')
   end

--- a/spec/features/gardens/index_spec.rb
+++ b/spec/features/gardens/index_spec.rb
@@ -37,10 +37,20 @@ RSpec.describe 'gardens index' do
     expect(current_path).to eq("/gardens/#{@north_boulder.id}")
   end
 
-  it 'has a link to create a new garden' do
+  it 'has buttons to edit each garden' do
     visit '/gardens'
 
-    click_link 'Create new garden'
+    within "div#garden-#{@north_boulder.id}" do
+      click_button 'Edit'
+    end
+
+    expect(current_path).to eq("/gardens/#{@north_boulder.id}/edit")
+  end
+
+  it 'has a button to create a new garden' do
+    visit '/gardens'
+
+    click_button 'New garden'
 
     expect(current_path).to eq('/gardens/new')
   end

--- a/spec/features/gardens/index_spec.rb
+++ b/spec/features/gardens/index_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'gardens index' do
   it 'has a link to create a new garden' do
     visit '/gardens'
 
-    click_button 'Create new garden'
+    click_link 'Create new garden'
 
     expect(current_path).to eq('/gardens/new')
   end

--- a/spec/features/gardens/index_spec.rb
+++ b/spec/features/gardens/index_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe 'gardens index' do
 
     expect(current_path).to eq("/gardens/#{@north_boulder.id}")
   end
+
+  it 'has a link to create a new garden' do
+    visit '/gardens'
+
+    click_button 'New garden'
+
+    expect(current_path).to eq('/gardens/new')
+  end
 end

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'create garden' do
     expect(current_path).to eq('/gardens/new')
 
     fill_in 'Name', with: 'New Community Garden'
-    fill_in 'Water on?', with: false
+    choose :water_on, option:false
     fill_in 'Water access points', with: 3
     click_on 'Create'
 

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -1,14 +1,3 @@
-# As a visitor
-# When I visit the Parent Index page
-# Then I see a link to create a new Parent record, "New Parent"
-# When I click this link
-# Then I am taken to '/parents/new' where I see a form for a new parent record
-# When I fill out the form with a new parent's attributes:
-# And I click the button "Create Parent" to submit the form
-# Then a POST request is sent to the '/parents' route,
-# a new parent record is created,
-# and I am redirected to the Parent Index page where I see the new Parent displayed.
-
 require 'rails_helper'
 
 RSpec.describe 'create garden' do

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'create garden' do
   it 'creates a new garden' do
     visit '/gardens'
 
-    click_link 'Create new garden'
+    click_button 'New garden'
 
     expect(current_path).to eq('/gardens/new')
 

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'create garden' do
   it 'creates a new garden' do
     visit '/gardens'
 
-    click_link 'New garden'
+    click_link 'Create new garden'
 
     expect(current_path).to eq('/gardens/new')
 

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe 'create garden' do
     expect(current_path).to eq('/gardens/new')
 
     fill_in 'Name', with: 'New Community Garden'
-    fill_in 'Water on?', with: 'No'
+    fill_in 'Water on?', with: false
     fill_in 'Water access points', with: 3
+    click_on 'Create'
 
     expect(current_path).to eq('/gardens')
     expect(page).to have_content('New Community Garden')

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -1,0 +1,29 @@
+# As a visitor
+# When I visit the Parent Index page
+# Then I see a link to create a new Parent record, "New Parent"
+# When I click this link
+# Then I am taken to '/parents/new' where I see a form for a new parent record
+# When I fill out the form with a new parent's attributes:
+# And I click the button "Create Parent" to submit the form
+# Then a POST request is sent to the '/parents' route,
+# a new parent record is created,
+# and I am redirected to the Parent Index page where I see the new Parent displayed.
+
+require 'rails_helper'
+
+RSpec.describe 'create garden' do
+  it 'creates a new garden' do
+    visit '/gardens'
+
+    click_link 'New garden'
+
+    expect(current_path).to eq('/gardens/new')
+
+    fill_in 'Name', with: 'New Community Garden'
+    fill_in 'Water on?', with: 'No'
+    fill_in 'Water access points', with: 3
+
+    expect(current_path).to eq('/gardens')
+    expect(page).to have_content('New Community Garden')
+  end
+end

--- a/spec/features/gardens/show_spec.rb
+++ b/spec/features/gardens/show_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'gardens index' do
   it 'has a button to see all garden plots for garden' do
     visit "/gardens/#{@north_boulder.id}"
 
-    click_link('See all plots')
+    click_button 'See all plots'
 
     expect(current_path).to eq("/gardens/#{@north_boulder.id}/plots")
   end

--- a/spec/features/gardens/show_spec.rb
+++ b/spec/features/gardens/show_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'gardens index' do
 
     visit "/gardens/#{new_garden.id}"
 
-    expect(page).to have_content("Garden added: 2021-01-01 07:00:00 UTC")
-    expect(page).to have_content("Last update: 2021-02-01 07:00:00 UTC")
+    expect(page).to have_content("Garden added: 2021-01-01")
+    expect(page).to have_content("Last update: 2021-02-01")
   end
 
   it 'has a button to see all garden plots for garden' do


### PR DESCRIPTION
## Changes

- Added a create and update form for gardens
- Linked those forms on the index
- Added a link to the garden show page for updating
- Added the `bootstrap_form` gem for styling the forms

## Special notes

I was going to ask Brian tomorrow about the bootstrap_form gem, but I assume it's OK since it's just for styling. You can do whatever with that, ignore it or use it to style your forms too. It's pretty usable and there's great documentation here: https://github.com/bootstrap-ruby/bootstrap_form

That said, if you do everything as normal, this will just not affect pages where you don't explicitly call it.

## Checklist

- [x] Tests written where required
- [x] All tests passing
- [x] SimpleCov at 100%

closes #30 
closes #31 